### PR TITLE
Add @dlqqq to Security Council

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Members
 - Rollin Thomas [@rcthomas](https://github.com/rcthomas)
 - Rick Wagner [@rpwagner](https://github.com/rpwagner)
 - Jason Weill [@jweill-aws](https://github.com/jweill-aws)
+- David L. Qiu [@dlqqq](https://github.com/dlqqq)
 - Joe Lucas [@josephtlucas](https://github.com/josephtlucas)
 
 The Jupyter Security Subproject representative to the [Jupyter Software Steering Council](https://jupyter.org/governance/software_steering_council.html) for 2023 is Rick Wagner ([@rpwagner](https://github.com/rpwagner)).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Members
 - Jason Grout [@jasongrout](https://github.com/jasongrout)
 - Rollin Thomas [@rcthomas](https://github.com/rcthomas)
 - Rick Wagner [@rpwagner](https://github.com/rpwagner)
-- Jason Weill [@jweill-aws](https://github.com/jweill-aws)
 - David L. Qiu [@dlqqq](https://github.com/dlqqq)
 - Joe Lucas [@josephtlucas](https://github.com/josephtlucas)
 


### PR DESCRIPTION
## Description

Adds @dlqqq (myself) to the Security Council, per this morning's Security WG call.

Will reach out to @JasonWeill to check on his availability to serve on the Jupyter Security Council moving forward into 2025.