### PR TITLE
Add script to report inactive users in GitHub orgs

### DIFF
--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -1,0 +1,141 @@
+"""
+This tools find all users in multiple organizations and print their last activity date.
+"""
+
+import os
+import asyncio
+import aiohttp
+from rich import print
+from datetime import datetime
+import humanize
+from itertools import count
+
+orgs = [
+    "binder-examples",
+    "binderhub-ci-repos", 
+    "ipython",
+    "jupyter",
+    "jupyter-book",
+    "jupyter-governance",
+    "jupyter-incubator",
+    "jupyter-server",
+    "jupyter-standards",
+    "jupyter-widgets",
+    "jupyterhub",
+    "jupyterlab",
+    "jupyter-xeus",
+    "jupytercon",
+    "voila-dashboards",
+    "voila-gallery",
+]
+
+token = os.getenv("GH_TOKEN")
+if not token:
+    print("[red]Error: GH_TOKEN environment variable not set[/red]")
+    exit(1)
+
+headers = {
+    "Authorization": f"token {token}",
+    "Accept": "application/vnd.github.v3+json",
+}
+
+async def get_org_members(session: aiohttp.ClientSession, org: str) -> list[dict]:
+    """Get all members for an organization
+    
+    Parameters
+    ----------
+    session: aiohttp.ClientSession
+        The aiohttp client session
+    org: str
+        The organization name
+        
+    Returns
+    -------
+    list[dict]: The list of members
+    """
+    members = []
+    
+    for page in count(1):
+        url = f"https://api.github.com/orgs/{org}/members?page={page}&per_page=100"
+        async with session.get(url, headers=headers) as response:
+            if response.status != 200:
+                print(f"[red]Error fetching members for {org}: {response.status}[/red]")
+                break
+                
+            page_members = await response.json()
+            if not page_members:
+                break
+                
+            members.extend(page_members)
+            
+    return members
+
+async def get_user_activity(session: aiohttp.ClientSession, username: str) -> datetime:
+    """Get the last activity date for a user
+    
+    Parameters
+    ----------
+    session: aiohttp.ClientSession
+        The aiohttp client session
+    username: str
+        The GitHub username
+        
+    Returns
+    -------
+    datetime: The last activity date
+    """
+    url = f"https://api.github.com/users/{username}/events/public"
+    async with session.get(url, headers=headers) as response:
+        if response.status == 200:
+            events = await response.json()
+            if events:
+                return datetime.fromisoformat(events[0]["created_at"].replace('Z', '+00:00'))
+    return None
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        # Check rate limit
+        async with session.get("https://api.github.com/rate_limit", headers=headers) as response:
+            if response.status == 200:
+                rate_data = await response.json()
+                remaining = rate_data["resources"]["core"]["remaining"]
+                reset_time = datetime.fromtimestamp(rate_data["resources"]["core"]["reset"])
+                reset_in = humanize.naturaltime(reset_time)
+                print(f"Rate limit remaining: {remaining}")
+                print(f"Rate limit resets {reset_in}")
+                if remaining < 100:
+                    print(f"[yellow]Warning: Low rate limit ({remaining} remaining)[/yellow]")
+                    if remaining < 10:
+                        print("[red]Aborting due to very low rate limit[/red]")
+                        return
+
+        # Get all members from all orgs
+        all_members = {}
+        for org in orgs:
+            members = await get_org_members(session, org)
+            for member in members:
+                if member["login"] not in all_members:
+                    all_members[member["login"]] = []
+                all_members[member["login"]].append(org)
+
+        # Get activity for each user
+        tasks = []
+        for username in all_members:
+            task = get_user_activity(session, username)
+            tasks.append((username, task))
+
+        results = await asyncio.gather(*(task for _, task in tasks))
+
+        # Print results sorted by last activity
+        user_activities = []
+        for (username, _), last_activity in zip(tasks, results):
+            if last_activity:
+                user_activities.append((username, last_activity, all_members[username]))
+
+        for username, last_activity, user_orgs in sorted(user_activities, key=lambda x: x[1], reverse=True):
+            last_activity_ago = humanize.naturaltime(datetime.now(last_activity.tzinfo) - last_activity)
+            orgs_str = ", ".join(user_orgs)
+            print(f"{username:<20}: Last activity {last_activity_ago} in orgs: {orgs_str}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -322,8 +322,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--timelimit-days",
         type=int,
-        default=0,
-        help="Time limit in days for the last activity (default: 30)",
+        default=365,
+        help="Maximum number of days since last activity before an account is marked as inactive. (default: 365)",
     )
     parser.add_argument(
         "--orgs",

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -19,22 +19,22 @@ from typing import Optional, List, Dict
 import argparse
 
 orgs = [
-    "binder-examples",
-    "binderhub-ci-repos",
+    # "binder-examples",
+    # "binderhub-ci-repos",
     "ipython",
-    "jupyter",
-    "jupyter-book",
-    "jupyter-governance",
-    "jupyter-incubator",
-    "jupyter-server",
-    "jupyter-standards",
-    "jupyter-widgets",
-    "jupyterhub",
-    "jupyterlab",
-    "jupyter-xeus",
-    "jupytercon",
-    "voila-dashboards",
-    "voila-gallery",
+    # "jupyter",
+    # "jupyter-book",
+    # "jupyter-governance",
+    # "jupyter-incubator",
+    # "jupyter-server",
+    # "jupyter-standards",
+    # "jupyter-widgets",
+    # "jupyterhub",
+    # "jupyterlab",
+    # "jupyter-xeus",
+    # "jupytercon",
+    # "voila-dashboards",
+    # "voila-gallery",
 ]
 
 token = os.getenv("GH_TOKEN")
@@ -76,95 +76,98 @@ async def get_org_members(session: aiohttp.ClientSession, org: str) -> List[Dict
     Pagination is handled automatically (100 items per page).
     """
     cache_key = f"org_members_{org}"
-    if cache_key in cache:
-        return cache[cache_key]
-
-    members = []
-    for page in count(1):
-        url = f"https://api.github.com/orgs/{org}/members?page={page}&per_page=100"
-        async with session.get(url, headers=headers) as response:
-            if response.status != 200:
-                print(f"[red]Error fetching members for {org}: {response.status}[/red]")
-                break
-                
-            page_members = await response.json()
-            if not page_members:
-                break
-                
-            members.extend(page_members)
     
-    cache.set(cache_key, members, expire=3600 * 24)
-    return members
+    # Try to get from cache
+    cached_data = cache.get(cache_key)
+    if cached_data is not None:
+        print(f"[cyan]Cache hit for {org} members[/cyan]")
+        return cached_data
+
+    print(f"[yellow]Cache miss for {org} members - fetching from API[/yellow]")
+    members = []
+    
+    try:
+        for page in count(1):
+            url = f"https://api.github.com/orgs/{org}/members?page={page}&per_page=100"
+            async with session.get(url, headers=headers) as response:
+                if response.status != 200:
+                    print(f"[red]Error fetching members for {org}: {response.status}[/red]")
+                    break
+                    
+                page_members = await response.json()
+                if not page_members:
+                    break
+                    
+                members.extend(page_members)
+        
+        # Cache the results
+        cache.set(cache_key, members, expire=3600 * 24)  # 24 hours
+        print(f"[green]Cached {len(members)} members for {org}[/green]")
+        return members
+        
+    except Exception as e:
+        print(f"[red]Error fetching members for {org}: {str(e)}[/red]")
+        return []
 
 async def get_user_activity(session: aiohttp.ClientSession, username: str) -> Optional[datetime]:
-    """Fetch the last public activity date for a GitHub user.
-
-    Parameters
-    ----------
-    session : aiohttp.ClientSession
-        The HTTP session to use for requests
-    username : str
-        The GitHub username to check
-
-    Returns
-    -------
-    Optional[datetime]
-        The datetime of the user's last public activity,
-        or None if no activity was found or an error occurred
-
-    Notes
-    -----
-    Results are cached for 24 hours to minimize API requests.
-    Only public events are considered for activity tracking.
-    """
+    """Fetch the last public activity date for a GitHub user."""
     cache_key = f"user_activity_{username}"
-    if cache_key in cache:
-        return cache[cache_key]
+    
+    # Try to get from cache
+    cached_data = cache.get(cache_key)
+    if cached_data is not None:
+        print(f"[cyan]Cache hit for {username} activity[/cyan]")
+        return cached_data
 
-    url = f"https://api.github.com/users/{username}/events/public"
-    async with session.get(url, headers=headers) as response:
-        if response.status == 200:
-            events = await response.json()
-            if events:
-                last_activity = datetime.fromisoformat(events[0]["created_at"].replace('Z', '+00:00'))
-                cache.set(cache_key, last_activity, expire=3600 * 24)
-                return last_activity
+    print(f"[yellow]Cache miss for {username} activity - fetching from API[/yellow]")
+    
+    try:
+        print(f"Getting activity for {username}")
+        url = f"https://api.github.com/users/{username}/events/public"
+        async with session.get(url, headers=headers) as response:
+            if response.status == 200:
+                print(f"Got activity for {username}")
+                events = await response.json()
+                if events:
+                    last_activity = datetime.fromisoformat(events[0]["created_at"].replace('Z', '+00:00'))
+                    # Cache the results
+                    cache.set(cache_key, last_activity, expire=3600 * 24)  # 24 hours
+                    print(f"[green]Cached activity for {username}[/green]")
+                    return last_activity
+                else:
+                    print(f"[yellow]No activity found for {username}[/yellow]")
+                    cache.set(cache_key, None, expire=3600 * 24)
+            else:
+                print(f"[red]Error fetching activity for {username}: {response.status}[/red]")
+    except Exception as e:
+        print(f"[red]Error fetching activity for {username}: {str(e)}[/red]")
+    
     return None
 
+def get_cache_size() -> str:
+    """Get the current cache size in a human-readable format."""
+    try:
+        cache_path = pathlib.Path(CACHE_DIR)
+        if cache_path.exists():
+            total_size = sum(f.stat().st_size for f in cache_path.rglob('*') if f.is_file())
+            return f"{total_size / 1024 / 1024:.1f} MB"
+    except Exception:
+        pass
+    return "unknown size"
+
 def clear_cache() -> None:
-    """Clear the disk cache.
-    
-    Removes all cached data, forcing fresh API requests on next run.
-    
-    Notes
-    -----
-    This is useful when you want to ensure you're getting the latest data
-    or if the cache becomes corrupted.
-    """
-    if pathlib.Path(CACHE_DIR).exists():
+    """Clear the disk cache."""
+    try:
         cache.clear()
         print("[green]Cache cleared successfully[/green]")
-    else:
-        print("[yellow]No cache directory found[/yellow]")
+    except Exception as e:
+        print(f"[red]Error clearing cache: {str(e)}[/red]")
 
 async def main():
-    """Main execution function.
-    
-    Fetches and displays the last activity for all members across specified organizations.
-    Uses disk caching to minimize API requests and handles GitHub API rate limits.
-
-    Notes
-    -----
-    The results are displayed organization by organization, with members sorted
-    by their last activity date (most recent first).
-    """
-    # Add cache info at start
-    cache_path = pathlib.Path(CACHE_DIR)
-    if cache_path.exists():
-        cache_size = sum(f.stat().st_size for f in cache_path.rglob('*') if f.is_file())
-        print(f"[blue]Using cache directory: {CACHE_DIR} ({cache_size / 1024 / 1024:.1f} MB)[/blue]")
-    else:
-        print("[yellow]Creating new cache directory[/yellow]")
+    """Main execution function."""
+    # Show cache status
+    print(f"[blue]Cache directory: {CACHE_DIR} (size: {get_cache_size()})[/blue]")
+    print(f"[blue]Cache contains {len(cache)} items[/blue]")
 
     async with aiohttp.ClientSession() as session:
         # Check rate limit
@@ -213,6 +216,7 @@ async def main():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="GitHub Organization Activity Tracker")
     parser.add_argument('--clear-cache', action='store_true', help='Clear the cache before running')
+    parser.add_argument('--debug', action='store_true', help='Show debug information')
     args = parser.parse_args()
 
     if args.clear_cache:

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -230,7 +230,7 @@ async def main():
         for (username, _), last_activity in zip(tasks, results):
             user_activities.append((username, last_activity, all_members[username]))
 
-        for username, last_activity, user_orgs in sorted(user_activities, key=lambda x: x[1] if x[1] is not None else datetime.fromtimestamp(0).astimezone(datetime.now().tzinfo), reverse=True):
+        for username, last_activity, user_orgs in sorted(user_activities, key=lambda x: x[1] if x[1] is not None else datetime.fromtimestamp(0), reverse=True):
             last_activity_ago = humanize.naturaltime(datetime.now(last_activity.tzinfo) - last_activity) if last_activity else "[red]never[/red]"
             orgs_str = ", ".join(user_orgs)
             print(f"{username:<20}: Last activity {last_activity_ago} in orgs: {orgs_str}")

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 orgs = [
     "binder-examples",
-    "binderhub-ci-repos", 
+    "binderhub-ci-repos",
     "ipython",
     "jupyter",
     "jupyter-book",

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -8,7 +8,7 @@ import os
 import asyncio
 import aiohttp
 from rich import print
-from datetime import datetime
+from datetime import datetime, timezone
 import humanize
 from itertools import count
 import aiosqlite
@@ -253,7 +253,15 @@ async def main():
         # Print results sorted by last activity
         user_activities = []
         for (username, _), last_activity in zip(tasks, results):
-            user_activities.append((username, last_activity, all_members[username]))
+            user_activities.append(
+                (
+                    username,
+                    datetime.fromisoformat(last_activity["__datetime__"])
+                    if last_activity is not None
+                    else datetime.fromtimestamp(0).replace(tzinfo=timezone.utc),
+                    all_members[username],
+                )
+            )
 
         for username, last_activity, user_orgs in sorted(
             user_activities,

--- a/tools/last_user_activity.py
+++ b/tools/last_user_activity.py
@@ -1,5 +1,7 @@
-"""
-This tools find all users in multiple organizations and print their last activity date.
+"""GitHub Organization Activity Tracker
+
+This module tracks and reports the last activity of members across GitHub organizations.
+It implements disk-based caching to minimize API requests and respect rate limits.
 """
 
 import os
@@ -13,7 +15,8 @@ import aiosqlite
 import diskcache
 import json
 import pathlib
-from typing import Optional
+from typing import Optional, List, Dict
+import argparse
 
 orgs = [
     "binder-examples",
@@ -48,8 +51,30 @@ headers = {
 CACHE_DIR = "github_cache"
 cache = diskcache.Cache(CACHE_DIR)
 
-async def get_org_members(session: aiohttp.ClientSession, org: str) -> list[dict]:
-    """Get all members for an organization with persistent caching"""
+async def get_org_members(session: aiohttp.ClientSession, org: str) -> List[Dict]:
+    """Fetch all members of a GitHub organization with caching.
+
+    Parameters
+    ----------
+    session : aiohttp.ClientSession
+        The HTTP session to use for requests
+    org : str
+        The name of the GitHub organization
+
+    Returns
+    -------
+    List[Dict]
+        A list of dictionaries containing member information.
+        Each dictionary contains at least:
+        - 'login': str, the username
+        - 'id': int, the user ID
+        - 'type': str, usually 'User'
+
+    Notes
+    -----
+    Results are cached for 24 hours to minimize API requests.
+    Pagination is handled automatically (100 items per page).
+    """
     cache_key = f"org_members_{org}"
     if cache_key in cache:
         return cache[cache_key]
@@ -68,11 +93,30 @@ async def get_org_members(session: aiohttp.ClientSession, org: str) -> list[dict
                 
             members.extend(page_members)
     
-    cache.set(cache_key, members, expire=3600 * 24)  # Cache for 24 hours
+    cache.set(cache_key, members, expire=3600 * 24)
     return members
 
 async def get_user_activity(session: aiohttp.ClientSession, username: str) -> Optional[datetime]:
-    """Get the last activity date for a user with persistent caching"""
+    """Fetch the last public activity date for a GitHub user.
+
+    Parameters
+    ----------
+    session : aiohttp.ClientSession
+        The HTTP session to use for requests
+    username : str
+        The GitHub username to check
+
+    Returns
+    -------
+    Optional[datetime]
+        The datetime of the user's last public activity,
+        or None if no activity was found or an error occurred
+
+    Notes
+    -----
+    Results are cached for 24 hours to minimize API requests.
+    Only public events are considered for activity tracking.
+    """
     cache_key = f"user_activity_{username}"
     if cache_key in cache:
         return cache[cache_key]
@@ -83,14 +127,42 @@ async def get_user_activity(session: aiohttp.ClientSession, username: str) -> Op
             events = await response.json()
             if events:
                 last_activity = datetime.fromisoformat(events[0]["created_at"].replace('Z', '+00:00'))
-                cache.set(cache_key, last_activity, expire=3600 * 24)  # Cache for 24 hours
+                cache.set(cache_key, last_activity, expire=3600 * 24)
                 return last_activity
     return None
 
-async def main():
-    # Add cache info at start
+def clear_cache() -> None:
+    """Clear the disk cache.
+    
+    Removes all cached data, forcing fresh API requests on next run.
+    
+    Notes
+    -----
+    This is useful when you want to ensure you're getting the latest data
+    or if the cache becomes corrupted.
+    """
     if pathlib.Path(CACHE_DIR).exists():
-        print(f"[blue]Using cache directory: {CACHE_DIR}[/blue]")
+        cache.clear()
+        print("[green]Cache cleared successfully[/green]")
+    else:
+        print("[yellow]No cache directory found[/yellow]")
+
+async def main():
+    """Main execution function.
+    
+    Fetches and displays the last activity for all members across specified organizations.
+    Uses disk caching to minimize API requests and handles GitHub API rate limits.
+
+    Notes
+    -----
+    The results are displayed organization by organization, with members sorted
+    by their last activity date (most recent first).
+    """
+    # Add cache info at start
+    cache_path = pathlib.Path(CACHE_DIR)
+    if cache_path.exists():
+        cache_size = sum(f.stat().st_size for f in cache_path.rglob('*') if f.is_file())
+        print(f"[blue]Using cache directory: {CACHE_DIR} ({cache_size / 1024 / 1024:.1f} MB)[/blue]")
     else:
         print("[yellow]Creating new cache directory[/yellow]")
 
@@ -139,4 +211,11 @@ async def main():
             print(f"{username:<20}: Last activity {last_activity_ago} in orgs: {orgs_str}")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="GitHub Organization Activity Tracker")
+    parser.add_argument('--clear-cache', action='store_true', help='Clear the cache before running')
+    args = parser.parse_args()
+
+    if args.clear_cache:
+        clear_cache()
+    
     asyncio.run(main())


### PR DESCRIPTION
This script try to pull the last activity of users across Jupyter Org. 

Note that this is likely this is the last activity of the user on GitHub, not on the org, so there might be users that are not contributing to jupyter anymore. 

For example, it show that I am active (as of a few hours ago) on orgs I haven't touched in month.