### PR TITLE
Add Erik Sundell to the Security Council

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Members
 - David L. Qiu [@dlqqq](https://github.com/dlqqq)
 - Joe Lucas [@josephtlucas](https://github.com/josephtlucas)
 - Rosio Reyes [@RRosio](https://github.com/RRosio)
+- Erik Sundell [@consideRatio](https://github.com/consideRatio)
 
 The Jupyter Security Subproject representative to the [Jupyter Software Steering Council](https://jupyter.org/governance/software_steering_council.html) for 2023 is Rick Wagner ([@rpwagner](https://github.com/rpwagner)).
 


### PR DESCRIPTION
From raising my request to join (#94) in a weekly meeting, I have understood I am approved to join. This PR makes it a bit more formal and can help me get external recognition for it which I could benefit from currently.

- closes #94