### PR TITLE
Mapping gh-repo <-> Pypi packages.

### DIFF
--- a/all_repos.txt
+++ b/all_repos.txt
@@ -1,0 +1,483 @@
+# github_org/repo : pypi url
+# the Pypi url can be empty if the repo has not matching package, or a dash
+# is the repo is eponymous
+
+
+jupyter-incubator/declarativewidgets_explorer : <none>
+jupyter-incubator/sparkmagic             : -
+jupyter-incubator/contentmanagement      : jupyter_cms
+jupyter-incubator/proposals              : <none>
+jupyter-widgets/ipywidgets               : -
+jupyter-server/jupyter-resource-usage    : -
+jupyter-server/jupyter_server            : jupyter-server
+jupyter-server/pytest-jupyter            : -
+jupyter-server/jupyter_server_mathjax    : -
+jupyter-server/gateway_provisioners      : gateway-provisioners
+jupyter-server/jupyter_releaser          : -
+jupyter-server/fps                       : -
+jupyter-server/jupyter_server_terminals  : -
+jupyter-server/jupyter_ydoc              : -
+jupyter-server/jupyter_server_fileid     : -
+jupyter-server/jupyter-scheduler         : -
+jupyter-server/pycrdt                    : -
+jupyter-server/pycrdt-websocket          : -
+jupyter-server/enterprise_gateway        : jupyter_enterprise_gateway
+jupyter-server/contributing-hour         : <none>
+ipython/ipython                          : -
+ipython/traitlets                        : -
+ipython/ipython_genutils                 : ipython_genutils
+ipython/ipyparallel                      : -
+ipython/ipykernel                        : -
+ipython/ipynb                            : -
+ipython/rlipython                        : -
+ipython/disp                             : -
+ipython/matplotlib-inline                : -
+ipython/comm                             : -
+ipython/ipython-pygments-lexers          : -
+jupyter-book/jupyter-book                : -
+jupyter/nbviewer                         : -
+jupyter/nbgrader                         : -
+jupyter/terminado                        : -
+jupyter/jupyter_core                     : -
+jupyter/nbformat                         : -
+jupyter/jupyter_client                   : -
+jupyter/notebook                         : -
+jupyter/nbconvert                        : -
+jupyter/jupyter_console                  : -
+jupyter/jupyter_kernel_test              : -
+jupyter/jupyter                          : -
+jupyter/nbdime                           : -
+jupyter/jupyterlab_geojson               : -
+jupyter/jupyter-sphinx                   : -
+jupyter/jupyter-packaging                : -
+jupyter/jupyterlab-fasta                 : -
+jupyter/nbclassic                        : -
+jupyter/nbclient                         : -
+jupyter/papyri                           : -
+jupyter/notebook_shim                    : -
+jupyter/jupyter_events                   : -
+jupyterlab/jupyterlab                    : -
+jupyterlab/jupyterlab-hdf5               : jupyterlab-hdf
+jupyterlab/pytest-check-links            : -
+# legacy server was launcher
+jupyterlab/jupyterlab_server             : jupyterlab-launcher
+jupyterlab/jupyterlab_server             : -
+jupyterlab/jupyterlab-git                : -
+jupyterlab/jupyterlab-github             : -
+jupyterlab/jupyterlab-latex              : -
+jupyterlab/jupyterlab-telemetry          : -
+jupyterlab/jupyterlab_pygments           : -
+jupyterlab/jupyterlab_apod               : -
+jupyterlab/jupyterlab-plugin-playground  : -
+jupyterlab/jupyterlab-translate          : -
+jupyterlab/hatch-jupyter-builder         : -
+jupyterlab/jupyter-collaboration         : -
+jupyterlab/jupyter-collaboration         : jupyter-server-ydoc
+jupyter/telemetry                        : jupyter-telemetry
+jupyter-standards/schemas                : <none>
+
+jupyterhealth/jupyter-smart-on-fhir      : -
+jupyterhealth/jupyterhealth-client       : -
+
+jupyterlab/jupyterlab-renderers          :jupyterlab-katex
+jupyterlab/jupyterlab-renderers          :jupyterlab-mathjax2
+jupyterlab/jupyterlab-renderers          :jupyterlab-mathjax3
+jupyterlab/jupyterlab-renderers          :jupyterlab-vega2
+jupyterlab/jupyterlab-renderers          :jupyterlab-vega3
+
+jupyterlab/pull-requests                 :jupyterlab-pullrequests
+
+# All these are from the same repo:
+jupyterlab/language-packs                :  jupyterlab-pseudo-language-pack
+jupyterlab/language-packs                :  jupyterlab-language-pack-ar-SA
+jupyterlab/language-packs                :  jupyterlab-language-pack-ca-ES
+jupyterlab/language-packs                :  jupyterlab-language-pack-cs-CZ
+jupyterlab/language-packs                :  jupyterlab-language-pack-da-DK
+jupyterlab/language-packs                :  jupyterlab-language-pack-de-DE
+jupyterlab/language-packs                :  jupyterlab-language-pack-el-GR
+jupyterlab/language-packs                :  jupyterlab-language-pack-es-ES
+jupyterlab/language-packs                :  jupyterlab-language-pack-et-EE
+jupyterlab/language-packs                :  jupyterlab-language-pack-fi-FI
+jupyterlab/language-packs                :  jupyterlab-language-pack-fr-FR
+jupyterlab/language-packs                :  jupyterlab-language-pack-he-IL
+jupyterlab/language-packs                :  jupyterlab-language-pack-hu-HU
+jupyterlab/language-packs                :  jupyterlab-language-pack-hy-AM
+jupyterlab/language-packs                :  jupyterlab-language-pack-id-ID
+jupyterlab/language-packs                :  jupyterlab-language-pack-it-IT
+jupyterlab/language-packs                :  jupyterlab-language-pack-ja-JP
+jupyterlab/language-packs                :  jupyterlab-language-pack-ko-KR
+jupyterlab/language-packs                :  jupyterlab-language-pack-lt-LT
+jupyterlab/language-packs                :  jupyterlab-language-pack-nl-NL
+jupyterlab/language-packs                :  jupyterlab-language-pack-no-NO
+jupyterlab/language-packs                :  jupyterlab-language-pack-pl-PL
+jupyterlab/language-packs                :  jupyterlab-language-pack-pt-BR
+jupyterlab/language-packs                :  jupyterlab-language-pack-ro-RO
+jupyterlab/language-packs                :  jupyterlab-language-pack-ru-RU
+jupyterlab/language-packs                :  jupyterlab-language-pack-tr-TR
+jupyterlab/language-packs                :  jupyterlab-language-pack-uk-UA
+jupyterlab/language-packs                :  jupyterlab-language-pack-vi-VN
+jupyterlab/language-packs                :  jupyterlab-language-pack-zh-CN
+jupyterlab/language-packs                :  jupyterlab-language-pack-zh-TW
+
+jupyterlab/jupyter-ai                    :  -
+jupyterlab/jupyter-builder               :  -
+jupyterlab/jupyterlab-data-explorer      :  -
+
+#
+jupyter/jupyter-sphinx-theme             :  -
+
+# variation in names:
+jupyterlab/jupyter-collaboration         :  jupyter-collaboration-ui
+jupyterlab/jupyter-collaboration         :  jupyter-docprovider
+jupyter-server/kernel_gateway            :  jupyter-kernel-gateway
+jupyter-server/synchronizer              :  jupyter-server-synchronizer
+
+# repo with no packages: <none>
+binderhub-ci-repos/lfs: <none>
+jupyter/design: <none>
+jupyter/security: <none>
+jupyter/ideas: <none>
+binderhub-ci-repos/lfs: <none>
+jupyter/governance: <none>
+jupyter/accessibility: <none>
+jupyter/cve: <none>
+
+# security forks:
+# is it safe to list those URL ?
+# REDACTED
+
+# .github repos
+jupyter-standard/.github    : <none>
+jupyter-server/.github      : <none>
+jupyter-xeus/.github        : <none>
+jupyter-standards/.github   : <none>
+ipython/.github             : <none>
+ipython/.github-1           : <none>
+jupyterhub/.github          : <none>
+voila-dashboards/.github    : <none>
+jupyter/.github             : <none>
+jupyterlab/.github          : <none>
+jupyter-governance/.github  : <none>
+
+
+jupyter-governance/jupyter-foundation-governing-board : <none>
+
+# .github.io repos
+ipython/ipython.github.com: <none>
+jupyter-xeus/jupyter-xeus.github.io: <none>
+jupyterhub/jupyterhub.github.io: <none>
+voila-gallery/voila-gallery.github.io: <none>
+voila-dashboards/voila-dashboards.github.io: <none>
+jupyter/jupyter.github.io: <none>
+
+# team compass
+jupyter/docs-team-compass: <none>
+jupyter/foundations-and-standards-team-compass: <none>
+jupyter/ipython-components: <none>
+jupyter/kernels-team-compass: <none>
+jupyter/notebook-team-compass: <none>
+jupyter/software-steering-council-team-compass: <none>
+jupyter/team-compass-template: <none>
+jupyter-book/team-compass: <none>
+jupyter-governance/ec-team-compass: <none>
+jupyter-server/team-compass: <none>
+jupyter-widgets/team-compass: <none>
+jupyterhub/team-compass: <none>
+jupyterlab/frontends-team-compass: <none>
+
+# misc websites:
+
+jupyter/cdn.jupyter.org: <none>
+jupyter/colaboratory.jupyter.org: <none>
+jupyter/nbviewer.org-deploy: <none>
+jupyter/try.jupyter.org: <none>
+jupyter-book/mystmd.org: <none>
+jupyterhub/mybinder.org-deploy: <none>
+jupyterhub/mybinder.org-user-guide: <none>
+voila-gallery/voila-gallery.org-deploy: <none>
+ipython/ipython-website: <none>
+
+# various tutorials
+jupyter/ngcm-tutorial: <none>
+jupyter/scipy-advanced-tutorial: <none>
+jupyter/strata-sv-2015-tutorial: <none>
+jupyter/tutorial-dashboards-declarativewidgets: <none>
+jupyter/tutorial-devteam-jupyterhub-2017: <none>
+jupyter/tutorial-devteam-projectmgt-2017: <none>
+jupyter-widgets/tutorial: <none>
+jupyter-widgets/tutorial-jupyterlite: <none>
+jupyterhub/jupyterhub-tutorial: <none>
+jupyterlab/jupytercon-jupyterlab-tutorial: <none>
+jupyterlab/scipy2018-jupyterlab-tutorial: <none>
+jupyterlab/scipy2019-jupyterlab-tutorial: <none>
+
+# exemples and cookie cutter
+voila-gallery/hello-world-example: <none>
+binderhub-ci-repos/cached-minimal-dockerfile: <none>
+binderhub-ci-repos/minimal-dockerfile: <none>
+binderhub-ci-repos/repo2docker-ci-clone-depth: <none>
+binderhub-ci-repos/repo2docker-subdir-support: <none>
+binderhub-ci-repos/requirements: <none>
+
+#
+ipython/pickleshare                 :  -
+jupyter/echo_kernel                 :  -
+jupyter/jupyter-alabaster-theme     :  -
+jupyter/jupyter_markdown            :  jupyter_markdown
+jupyter/jupyterhub-carina           :  -
+jupyter/nb2kg                       :  -
+jupyter/qtconsole                   :  -
+jupyter/sphinxcontrib_github_alt    :  sphinxcontrib_github_alt
+jupyter/testpath                    :  -
+jupyter/tmpnb                       :  -
+jupyter-book/hatch-deps-selector    :  -
+jupyter-book/jupyter_releaser       :  -
+jupyter-book/jupyterlab-myst        :  -
+jupyter-book/jupyterlab-myst-quickstart : <none>
+jupyter-book/myst-spec              :  -
+jupyter-book/mystmd                 :  -
+jupyter-book/sphinx-ext-mystmd      :  -
+
+jupyter-book/book-theme-tailwind-quickstart : <none>
+jupyter-book/jupyterlab-myst-quickstart     : <none>
+jupyter-book/legacy-demo-book               : <none>
+jupyter-book/myst-enhancement-proposals     : <none>
+jupyter-book/myst-theme                     : <none>
+jupyter-book/mystmd-quickstart              : <none>
+jupyter-book/vscode-mystmd                  : <none>
+
+# jupyter widgets
+
+jupyter-widgets/ipydatagrid               :  -
+jupyter-widgets/ipyleaflet                :  -
+jupyter-widgets/pythreejs                 :  -
+jupyter-widgets/traittypes                :  -
+
+
+# jupyterhub
+jupyterhub/design                           : <none>
+jupyterhub/action-get-quayio-tags           : <none>
+jupyterhub/action-k3s-helm                  : <none>
+jupyterhub/action-k8s-await-workloads       : <none>
+jupyterhub/action-k8s-namespace-report      : <none>
+jupyterhub/action-major-minor-tag-calculator: <none>
+
+
+jupyterhub/alabaster-jupyterhub                 : -
+jupyterhub/batchspawner                         : -
+jupyterhub/binderhub                            : -
+jupyterhub/chartpress                           : -
+jupyterhub/configurable-http-proxy              : -
+jupyterhub/docker-image-cleaner                 : -
+jupyterhub/dockerspawner                        : -
+jupyterhub/gh-scoped-creds                      : -
+jupyterhub/jupyter-remote-desktop-proxy         : -
+jupyterhub/jupyter-rsession-proxy               : -
+jupyterhub/jupyter-server-proxy                 : -
+jupyterhub/nbgitpuller                          : -
+jupyterhub/jupyterhub                           : -
+jupyterhub/jupyterhub-idle-culler               : -
+jupyterhub/jupyterhub-sphinx-theme              : -
+jupyterhub/nbgitpuller-downloader-dropbox       : -
+jupyterhub/nbgitpuller-downloader-generic-web   : -
+jupyterhub/nbgitpuller-downloader-googledrive   : -
+jupyterhub/nullauthenticator                    : -
+jupyterhub/oauthenticator                       : -
+jupyterhub/pytest-jupyterhub                    : -
+jupyterhub/simpervisor                          : -
+jupyterhub/sudospawner                          : -
+jupyterhub/wrapspawner                          : -
+jupyterhub/escapism                             : -
+jupyterhub/pamela                               : -
+jupyterhub/autodoc-traits                       : -
+
+# seem to append jupyter- in front of the repo name
+jupyterhub/repo2docker                          : jupyter-repo2docker
+
+# seem to append jupyterhub- in front of the repo name
+jupyterhub/kerberosauthenticator                : jupyterhub-kerberosauthenticator
+jupyterhub/ldapauthenticator                    : jupyterhub-ldapauthenticator
+jupyterhub/ltiauthenticator                     : jupyterhub-ltiauthenticator
+jupyterhub/nativeauthenticator                  : jupyterhub-nativeauthenticator
+jupyterhub/dummyauthenticator                   : jupyterhub-dummyauthenticator
+jupyterhub/firstuseauthenticator                : jupyterhub-firstuseauthenticator
+jupyterhub/simplespawner                        : jupyterhub-simplespawner
+jupyterhub/systemdspawner                       : jupyterhub-systemdspawner
+jupyterhub/tmpauthenticator                     : jupyterhub-tmpauthenticator
+jupyterhub/traefik-proxy                        : jupyterhub-traefik-proxy
+jupyterhub/yarnspawner                          : jupyterhub-yarnspawner
+jupyterhub/kubespawner                          : jupyterhub-kubespawner
+
+
+# misc name don't match
+jupyter-widgets/jupyterlab-sidecar              : sidecar
+jupyter-widgets/midicontrols                    : ipymidicontrols
+jupyter-widgets/xeus                            : xeus-python
+
+jupyter/declarativewidgets                      : jupyter_declarativewidgets/
+
+jupyter/kernel_gateway_bundlers                 : jupyter_kernel_gateway_bundlers/
+
+
+
+
+# Jupyter XEUS
+
+jupyter-xeus/robotframework-interpreter   :  robotframework-interpreter
+jupyter-xeus/xeus-python                  :  xeus-python
+jupyter-xeus/xeus-python-shell            :  xeus-python-shell
+jupyter-xeus/xeus-robot                   :  xeus-robot
+jupyter-xeus/xeus-robot-wheel             :  xeus-robot
+
+
+# Voilà
+
+voila-dashboards/hotpot_km                :  hotpot_km
+voila-dashboards/voici                    :  voici
+voila-dashboards/voila                    :  voila
+voila-dashboards/voila-debug              :  voila-debug
+voila-dashboards/voila-gridstack          :  voila-gridstack
+voila-dashboards/voila-material           :  voila-material
+voila-dashboards/voila-reveal             :  voila-reveal
+voila-dashboards/voila-topbar             :  voila-topbar
+voila-dashboards/voila-vuetify            :  voila-vuetify
+
+
+jupyter-server/jupyverse                  :  -
+jupyterlab/lumino                         : <none>
+jupyterlab/retrolab                       :  -
+jupyterlab/rtc                            : <none>
+
+# not packages
+ipython/dfflib  : <none>
+ipython/front-to-back : <none>
+ipython/ipython-ansible-jenkins : <none>
+ipython/ipython-doc : <none>
+ipython/ipython-in-depth: <none>
+ipython/ipython-sec  : <none>
+ipython/marketing : <none>
+ipython/mozfest2014 : <none>
+ipython/nbviewer-deploy  : <none>
+ipython/paper-notebook2013 : <none>
+ipython/salt-states-nbviewer : <none>
+ipython/sloan-2013-reports : <none>
+ipython/talks : <none>
+ipython/usersurveys : <none>
+ipython/xkcd-font: <none>
+
+jupyter/dashboards : jupyter_dashboards
+
+# nodes packages
+
+jupyter/jupyter-js-cells : <none>
+jupyter/jupyter-js-docmanager : <none>
+jupyter/jupyter-js-domutils : <none>
+jupyter/jupyter-js-editor : <none>
+jupyter/jupyter-js-filebrowser : <none>
+jupyter/jupyter-js-input-area : <none>
+jupyter/jupyter-js-notebook : <none>
+jupyter/jupyter-js-output-area : <none>
+jupyter/jupyter-js-phosphide : <none>
+jupyter/jupyter-js-plugins : <none>
+jupyter/jupyter-js-terminal : <none>
+jupyter/jupyter-js-ui : <none>
+jupyter/jupyter-js-utils : <none>
+
+
+# Own by the matplotlib org:
+voila-gallery/ipympl                      :  ipympl
+
+
+jupyterlab/jupyter-chat                   :  jupyterlab-chat
+
+# misc
+
+jupyter/nbmanager : <none>
+jupyter/conf-event-log: <none>
+jupyter/cookiecutter-docker-stacks: <none>
+
+
+jupyter/dashboards_bundlers : jupyter_dashboards_bundlers
+jupyter/dashboards_server : <none>
+jupyter/dashboards_setup : <none>
+jupyter/distinguished-contributors: <none>
+jupyter/docker-demo-images: <none>
+jupyter/docker-notebook: <none>
+jupyter/docker-stacks: <none>
+jupyter/enhancement-proposals: <none>
+jupyter/etph: <none>
+
+
+jupyter-widgets/widget-cookiecutter: <none>
+jupyter-widgets/widget-ts-cookiecutter: <none>
+
+voila-gallery/cpp-xleaflet                 : <none>
+voila-gallery/electricitymap_dashboard     : <none>
+voila-gallery/gaussian-density             : <none>
+voila-gallery/render-stl                   : <none>
+voila-gallery/voila-spotify                : <none>
+
+
+jupyterlab/ui-profiler: jupyterlab-ui-profiler
+jupyterlab/ux-research: <none>
+jupyterlab/vscode-config-template: <none>
+jupyterlab/richoutput-js: <none>
+jupyterlab/jupyterlab_xkcd: <none>
+jupyterlab/mimerender-cookiecutter: <none>
+jupyterlab/jupyterlab-commenting: jupyterlab-commenting-service
+jupyterlab/jupyterlab-celltags: <none>
+jupyterlab/jupyterlab-bot: <none>
+
+
+
+voila-dashboards/tljh-voila-gallery         : <none>
+voila-dashboards/voici-demo                 : <none>
+voila-dashboards/voici-gallery              : <none>
+voila-dashboards/voila-heroku               : <none>
+voila-dashboards/voila-huggingface          : <none>
+voila-dashboards/voila-railway              : <none>
+voila-dashboards/voila-template-cookiecutter: <none>
+
+jupyterlab/jupyterlab-mp4 : <none>
+jupyterlab/jupyterlab-demo: <none>
+jupyterlab/galata         : <none>
+jupyterhub/outreachy                    : <none>
+jupyterhub/pebble-helm-chart            : <none>
+jupyterhub/repo2docker-action           : <none>
+jupyterhub/research-facilities          : <none>
+jupyterhub/the-littlest-jupyterhub      : <none>
+jupyterhub/zero-to-jupyterhub-k8s       : <none>
+jupyterhub/mybinder-tools               : <none>
+jupyterhub/jupyterlab-hub               : <none>
+jupyterhub/jupyterhub-the-hard-way      : <none>
+jupyterhub/hubshare                     : <none>
+
+
+jupyter/scipy-2015-advanced-topics  : <none>
+jupyter/scipy-sprint                : <none>
+jupyter/surveys                     : <none>
+jupyter/nbshot                      : <none>
+jupyter/nbcache                     : <none>
+jupyter/nature-demo                 : <none>
+jupyter/jupyter_logger              : <none>
+jupyter/lbnl-jupyterday             : <none>
+jupyter/joss-papers                 : <none>
+jupyter/help                        : <none>
+jupyter/jupyter-blog-theme          : <none>
+jupyter/jupyter-communitycalls      : <none>
+
+
+jupyter-book/blog                   : <none>
+
+jupyterlab/benchmarks               : <none>
+jupyterlab/debugger                 : <none>
+jupyter-book/meta                   : <none>
+jupyter/tmpnb-redirector            : <none>
+jupyter/atom-notebook               : <none>
+jupyter/jupyterlab_json             : <none>
+jupyter/jupyterhub-2016-workshop    : <none>
+jupyter/ipython-py3k                : <none>
+jupyter/debugger                    : <none>
+jupyter/experiments                 : <none>
+jupyter/kernels                     : <none>
+jupyter/markdown                    : <none>

--- a/all_repos.txt
+++ b/all_repos.txt
@@ -481,3 +481,20 @@ jupyter/debugger                    : <none>
 jupyter/experiments                 : <none>
 jupyter/kernels                     : <none>
 jupyter/markdown                    : <none>
+jupyterhub/jhub-proposals           : <none>
+
+
+jupyter/colaboratory                : <none>
+jupyter-server/extension-cookiecutter : <none>
+jupyter/extension-builder           : <none>
+jupyter/jsplugins                   : <none>
+jupyter/jupyter-drive               : jupyterdrive
+jupyter/jupyter-sprints             : <none>
+jupyter/jupytercon2023              : <none>
+jupyterhub/jupyterhub-deploy-docker : <none>
+jupyterhub/jupyterhub-deploy-hpc    : <none>
+jupyterhub/jupyterhub-deploy-teaching : <none>
+
+jupyter/jvm-magics                  : <none>
+jupyter/jvm-repr                    : <none>
+jupyter/kernel-protocol             : <none>

--- a/all_repos.txt
+++ b/all_repos.txt
@@ -498,3 +498,19 @@ jupyterhub/jupyterhub-deploy-teaching : <none>
 jupyter/jvm-magics                  : <none>
 jupyter/jvm-repr                    : <none>
 jupyter/kernel-protocol             : <none>
+jupyter/nbindex                     : <none>
+jupyter/tmpnb-deploy                : <none>
+jupyter/nbconvert-examples          : <none>
+jupyterhub/binder-billing           : <none>
+jupyter-xeus/xeus-calc              : <none>
+jupyter/kernel_gateway_demos        : <none>
+jupyter/notebook-research           : <none>
+jupyter/mozfest15-training          : <none>
+jupyter/spreadsheet                 : <none>
+
+jupyter/newsletter                  : <none>
+jupyter/practice                    : <none>
+jupyter/roadmap                     : <none>
+jupyter/schema                      : <none>
+jupyter/services                    : <none>
+jupyter/showcase                    : <none>

--- a/all_repos.txt
+++ b/all_repos.txt
@@ -9,6 +9,7 @@ jupyter-incubator/contentmanagement      : jupyter_cms
 jupyter-incubator/proposals              : <none>
 jupyter-widgets/ipywidgets               : -
 jupyter-server/jupyter-resource-usage    : -
+jupyter-server/jupyter-resource-usage    : nbresuse
 jupyter-server/jupyter_server            : jupyter-server
 jupyter-server/pytest-jupyter            : -
 jupyter-server/jupyter_server_mathjax    : -
@@ -47,7 +48,7 @@ jupyter/jupyter_console                  : -
 jupyter/jupyter_kernel_test              : -
 jupyter/jupyter                          : -
 jupyter/nbdime                           : -
-jupyter/jupyterlab_geojson               : -
+jupyter/jupyterlab_geojson               : <none>
 jupyter/jupyter-sphinx                   : -
 jupyter/jupyter-packaging                : -
 jupyter/jupyterlab-fasta                 : -
@@ -223,7 +224,8 @@ binderhub-ci-repos/requirements: <none>
 ipython/pickleshare                 :  -
 jupyter/echo_kernel                 :  -
 jupyter/jupyter-alabaster-theme     :  -
-jupyter/jupyter_markdown            :  jupyter_markdown
+# under datalayer org
+jupyter/jupyter_markdown            :  <none>
 jupyter/jupyterhub-carina           :  -
 jupyter/nb2kg                       :  -
 jupyter/sphinxcontrib_github_alt    :  sphinxcontrib_github_alt
@@ -426,6 +428,17 @@ jupyterlab/mimerender-cookiecutter: <none>
 jupyterlab/jupyterlab-commenting: jupyterlab-commenting-service
 jupyterlab/jupyterlab-celltags: <none>
 jupyterlab/jupyterlab-bot: <none>
+jupyterlab/jupytercon-jupyterlab-training : <none>
+jupyterlab/theme-cookiecutter : <none>
+jupyterlab/runall-extension : <none>
+jupyterlab/mimerender-cookiecutter-ts : <none>
+jupyterlab/jupyterlab-toc : <none>
+jupyterlab/maintainer-tools: <none>
+jupyterlab/language-pack-cookiecutter : <none>
+jupyterlab/jupyterlab-statusbar : <none>
+jupyterlab/jupyterlab-shortcutui : <none>
+jupyterlab/jupyterlab-probot : <none>
+jupyterlab/jupyterlab-monaco : <none>
 
 
 
@@ -450,6 +463,13 @@ jupyterhub/mybinder-tools               : <none>
 jupyterhub/jupyterlab-hub               : <none>
 jupyterhub/jupyterhub-the-hard-way      : <none>
 jupyterhub/hubshare                     : <none>
+
+
+jupyterlab/jupyter-renderers : jupyterlab-fasta
+jupyterlab/jupyter-renderers : jupyterlab-geojson
+jupyterlab/jupyter-renderers : jupyterlab-katex
+jupyterlab/jupyter-renderers : jupyterlab-mathjax2
+jupyterlab/jupyter-renderers : jupyterlab-vega3
 
 
 jupyter/scipy-2015-advanced-topics  : <none>
@@ -513,3 +533,11 @@ jupyter/roadmap                     : <none>
 jupyter/schema                      : <none>
 jupyter/services                    : <none>
 jupyter/showcase                    : <none>
+
+
+jupyterlab/jupyterlab-module-federation : <none>
+jupyterlab/jupyterlab-metadata-service : <none>
+jupyterlab/jupyterlab-media : <none>
+jupyter-server/council : <none>
+
+jupyterlab/hatch-nodejs-version  :  hatch-nodejs-version

--- a/all_repos.txt
+++ b/all_repos.txt
@@ -264,7 +264,7 @@ jupyterhub/action-k8s-namespace-report      : <none>
 jupyterhub/action-major-minor-tag-calculator: <none>
 
 
-jupyterhub/alabaster-jupyterhub                 : -
+jupyterhub/alabaster-jupyterhub                 : alabaster_jupyterhub
 jupyterhub/batchspawner                         : -
 jupyterhub/binderhub                            : -
 jupyterhub/chartpress                           : -

--- a/all_repos.txt
+++ b/all_repos.txt
@@ -226,7 +226,6 @@ jupyter/jupyter-alabaster-theme     :  -
 jupyter/jupyter_markdown            :  jupyter_markdown
 jupyter/jupyterhub-carina           :  -
 jupyter/nb2kg                       :  -
-jupyter/qtconsole                   :  -
 jupyter/sphinxcontrib_github_alt    :  sphinxcontrib_github_alt
 jupyter/testpath                    :  -
 jupyter/tmpnb                       :  -
@@ -385,7 +384,7 @@ jupyter/jupyter-js-utils : <none>
 
 
 # Own by the matplotlib org:
-voila-gallery/ipympl                      :  ipympl
+voila-gallery/ipympl                      :  <none>
 
 
 jupyterlab/jupyter-chat                   :  jupyterlab-chat

--- a/tools/all_repos.py
+++ b/tools/all_repos.py
@@ -22,6 +22,19 @@ import requests
 from rich import print
 from bs4 import BeautifulSoup
 
+maintainers_name_map = {
+    "mbussonn": "Carreau",
+    "takowl": "takluyver",
+    "Kyle.Kelley": "rgbkrk",
+    "bgranger": "ellisonbg",
+}
+
+import diskcache
+from datetime import datetime
+
+CACHE_DIR = f"github_cache-all_repos-{datetime.now().strftime('%Y%m')}"
+cache = diskcache.Cache(CACHE_DIR)
+
 
 def get_packages(url):
     # Send a GET request to the webpage with a custom user agent
@@ -85,7 +98,7 @@ headers = {
 }
 
 
-async def list_repos(orgs):
+async def list_github_repos(orgs):
     async with trio.open_nursery() as nursery:
         results = []
         for org in orgs:
@@ -94,9 +107,10 @@ async def list_repos(orgs):
                 results.append(await list_repos_for_org(org))
 
             nursery.start_soon(_loc, results, org)
+
     for org_repos in results:
-        for org, repo in org_repos:
-            yield org, repo
+        for org, repo, archived, private in org_repos:
+            yield org, repo, archived, private
 
 
 async def list_repos_for_org(org):
@@ -109,75 +123,234 @@ async def list_repos_for_org(org):
         response.raise_for_status()
         repos = response.json()
         for repo in repos:
-            reps.append((org, repo["name"]))
+            archived = repo.get("archived", None)
+            private = repo.get("private", None)
+            reps.append((org, repo["name"], archived, private))
         if len(repos) < 100:
             break
     return reps
 
 
-async def main():
+async def get_package_maintainers(package: str) -> tuple[list[str], bool]:
+    """Get the maintainers of a package from PyPI.
 
+    The json does not have the right information, so we need to scrape the page.
+    """
+    assert package, "package is required"
+    url = f"https://pypi.org/project/{package}/"
+    if package in cache:
+        print("c", end="", flush=True)
+        return cache[package], True
+    response = await asks.get(url)
+    # fastly html is 200 even if package is not found, so the json instead
+    assert len(package.strip()) > 2, package
+    url = f"https://pypi.org/pypi/{package}/json"
+
+    try:
+        (await asks.get(url)).raise_for_status()
+    except Exception as e:
+        raise ValueError("For package", package) from e
+    if response.status_code == 200:
+        html = response.text
+        soup = BeautifulSoup(html, "html.parser")
+        maintainers = soup.find_all("span", class_="sidebar-section__maintainer")
+        if not maintainers:
+            print("x", end="", flush=True)
+            return set(["unknown (blocked by fastly?)"]), False
+        res = set(a.text.strip() for a in maintainers)
+        cache[package] = res
+        print(".", end="", flush=True)
+        return res, True
+    print("f", end="", flush=True)
+    return set(["unknown (status code: " + str(response.status_code) + ")"]), False
+
+
+async def main(config_file: str = "all_repos.txt"):
+    from pathlib import Path
+
+    items = Path(config_file).read_text().splitlines()
+    known_mapping = []
+    for item in items:
+        if item.startswith("#") or not item.strip():
+            continue
+        if item.count(":") == 0:
+            print(f"Invalid line: {item}")
+            exit(1)
+        github_slug, pypi_url = item.split(":", maxsplit=1)
+        github_slug = github_slug.strip(" /")
+        ghorg, repo = github_slug.split("/")
+        assert repo
+        pypi_url = pypi_url.replace("<none>", "").strip(" /")
+        if pypi_url == "-":
+            pypi_url = f"https://pypi.org/project/{repo.replace('_', '-')}"
+        if "https://pypi.org/project/" not in pypi_url and pypi_url != "":
+            pypi_url = f"https://pypi.org/project/{pypi_url}"
+
+        # pypi name may be empty for repo with no packages.
+        # and one repo can create multiple pypi packages.
+        assert pypi_url != "https://pypi.org/project/"
+        known_mapping.append((github_slug, pypi_url))
+
+    # get all packages in the pypi jupyter org
     packages = get_packages(f"https://pypi.org/org/jupyter/")
+    packages_urls = [f"https://pypi.org/project/{p}" for p in packages]
     print(f"Found {len(packages)} packages in the pypi jupyter org")
 
-    map = {p.lower().replace("-", "_"): p for p in packages}
-
-    todo = []
-    async for org, repo in list_repos(default_orgs):
-        lowname = repo.lower().replace("-", "_")
-        if lowname in map:
-            print(
-                f"{org}/{repo}".ljust(40),
-                f"https://pypi.org/project/{map[lowname]}",
-                " in jupyter org",
-            )
-            del map[lowname]
-        else:
-            todo.append((org, repo))
-
-    print()
-    print("check potentially matching Pypi names:")
+    missing_from_pypi_org = (
+        set([p for _, p in known_mapping]) - set(packages_urls) - {""}
+    )
 
     async with trio.open_nursery() as nursery:
         targets = []
-        for org, repo in todo:
+        semaphore = trio.Semaphore(15)  # Throttle to 10 concurrent requests
+        for package_url in missing_from_pypi_org:
 
-            async def _loc(targets, org, repo):
-                targets.append(
-                    (
-                        org,
-                        repo,
+            async def _loc(targets, package_url):
+                async with semaphore:  # Wait for semaphore to be available
+                    package = package_url.strip("/").split("/")[-1]
+                    assert package != "project", package_url
+                    assert package, f"package is required {package_url}"
+                    maintainers, is_ok = await get_package_maintainers(package)
+                    targets.append(
                         (
-                            await asks.get(f"https://pypi.org/pypi/{repo}/json")
-                        ).status_code,
+                            package_url,
+                            maintainers,
+                            is_ok,
+                        )
                     )
-                )
 
-            nursery.start_soon(_loc, targets, org, repo)
+            nursery.start_soon(_loc, targets, package_url)
+    by_maintainers = {}
+    if targets:
+        print()
+        print(
+            f"{len(targets)} To add to PiPy org – they are listed on the config file, with a "
+            "corresponding Pypi package, but the package is not part of Pypi org:"
+        )
+        for package_url, maintainers, is_ok in targets:
+            print(f"  [yellow]{package_url}[/yellow] maintained by")
+            for maintainer in maintainers:
+                color = "[green]" if is_ok else "[red]"
+                end = "[/green]" if is_ok else "[/red]"
+                print(f"{color}     pypi: `@{maintainer}` {end}")
+                if is_ok:
+                    by_maintainers[maintainer] = by_maintainers.setdefault(
+                        maintainer, []
+                    )
+                    by_maintainers[maintainer].append(package_url)
+        print()
+
+    by_maintainers = {
+        k: v
+        for k, v in sorted(
+            by_maintainers.items(), key=lambda item: len(item[1]), reverse=True
+        )
+    }
+    for maintainer, packages in by_maintainers.items():
+        print(
+            f"[green]`@{maintainer}`[/green] {len(packages)} packages (https://pypi.org/user/{maintainer}/):"
+        )
+        for package in sorted(packages):
+            print(f"    {package}")
+
+    missing_from_github_org = set(packages_urls) - set([p for _, p in known_mapping])
+    if missing_from_github_org:
+        print(
+            "Packages missing from github org, they are on PyPI, but I don't know"
+            " the source github repo...:"
+        )
+        for repo in sorted(missing_from_github_org):
+            print(f"  {repo}")
+
+    todo = []
+
+    # we've verified the existing mapping,
+    # now up to all the org/repo that are not inther
+
+    print(
+        "listing all org and repo under jupyter purview, and filtering one without"
+        " mathching github repos."
+    )
+
+    known_org_rep = {k for k, v in known_mapping}
+    async for org, repo, archived, private in list_github_repos(default_orgs):
+        org_repo = f"{org}/{repo}"
+        if org_repo in known_org_rep:
+            continue
+        assert repo
+        todo.append((org, repo, archived, private))
+
+    print()
+    print(
+        "check potentially matching Pypi names, all the following seem to correspond"
+        " to an existing pypi package, if they indeed are part of Jupyter, "
+        "you can copy past the lines as is in the config file. If not just append: `{org}/{repo}:`"
+    )
+
+    async with trio.open_nursery() as nursery:
+        targets = []
+        semaphore = trio.Semaphore(15)  # Throttle to 10 concurrent requests
+        for org, repo, archived, private in todo:
+            assert repo
+
+            async def _loc(targets, org, repo, archived, private):
+                async with semaphore:  # Wait for semaphore to be available
+                    # maintainers = await get_package_maintainers(repo)
+                    maintainers = []
+                    assert repo
+                    targets.append(
+                        (
+                            org,
+                            repo,
+                            (
+                                await asks.get(f"https://pypi.org/pypi/{repo}/json")
+                            ).status_code,
+                            maintainers,
+                            archived,
+                            private,
+                        )
+                    )
+
+            nursery.start_soon(_loc, targets, org, repo, archived, private)
+
     corg = ""
-    for org, repo, status in sorted(targets):
+    for org, repo, status, maintainers, archived, private in sorted(targets):
         if org != corg:
             print()
             corg = org
         if status == 200:
             print(
-                f"https://github.com/{org}/{repo}".ljust(70),
-                f"{status} for https://pypi.org/project/{repo}",
+                f"https://github.com/{org}/{repo}".ljust(40),
+                f" :  https://pypi.org/project/{repo}",
+                f"[yellow]{'(archived)' if archived else ''}[/yellow] [red]{'(private)' if private else ''}[/red]".ljust(
+                    20
+                ),
             )
 
+            # for maintainer in maintainers:
+            #    if maintainer in maintainers_name_map:
+            #        print(f"  @{maintainers_name_map[maintainer]} ({maintainer})")
+            #    else:
+            #        print(f"  @{maintainer}")
+
     print()
-    print("repos with no Pypi package:")
+    print(
+        "repos with no Pypi package, either manually add `{org}/{repo}: "
+        "{pypi_url}` or `{org}/{repo}: <none>` to config file."
+    )
     corg = ""
-    for org, repo, status in sorted(targets):
+    counter = 0
+    for org, repo, status, maintainers, archived, private in sorted(targets):
         if org != corg:
             print()
             corg = org
         if status != 200:
-            print(f"https://github.com/{org}/{repo}")
-
-    print()
-    print("Packages with no repos.")
-    print(map)
+            counter += 1
+            print(
+                counter,
+                f"https://github.com/{org}/{repo}".ljust(30),
+                f"[yellow]{'(archived)' if archived else ''}[/yellow] [red]{'(private)' if private else ''}[/red]",
+            )
 
 
 trio.run(main)

--- a/tools/all_repos.py
+++ b/tools/all_repos.py
@@ -227,7 +227,7 @@ async def main(config_file: str = "all_repos.txt"):
             f"{len(targets)} To add to PiPy org – they are listed on the config file, with a "
             "corresponding Pypi package, but the package is not part of Pypi org:"
         )
-        for package_url, maintainers, is_ok in targets:
+        for package_url, maintainers, is_ok in sorted(targets):
             print(f"  [yellow]{package_url}[/yellow] maintained by")
             for maintainer in maintainers:
                 color = "[green]" if is_ok else "[red]"

--- a/tools/tide.py
+++ b/tools/tide.py
@@ -74,6 +74,7 @@ def get_tidelift_data(packages):
 
     # Create a table for aligned output
     table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("#")
     table.add_column("Package Name")
     table.add_column("Estimated Money")
     table.add_column("Lifted")
@@ -89,11 +90,11 @@ def get_tidelift_data(packages):
     package_data.sort(
         key=lambda x: (x[1] is None, x[1], -maybefloat(x[2]), x[0])
     )  # sort lifted True first, then None, then False, then amount,  then by name
-    for name, lifted, estimated_money in package_data:
+    for i, (name, lifted, estimated_money) in enumerate(package_data, start=1):
         if lifted:
-            table.add_row(name, "-- need login ––", f"[green]{lifted}[/green]")
+            table.add_row(str(i), name, "-- need login ––", f"[green]{lifted}[/green]")
         else:
-            table.add_row(name, str(estimated_money), f"[red]{lifted}[/red]")
+            table.add_row(str(i), name, str(estimated_money), f"[red]{lifted}[/red]")
 
     print(table)
 

--- a/tools/tide.py
+++ b/tools/tide.py
@@ -45,7 +45,7 @@ def get_packages(url):
     return h3_tags
 
 
-def get_tidelift_data(packages):
+def get_tidelift_data(packages, only_liftable=False):
     packages_data = [{"platform": "pypi", "name": h3} for h3 in packages]
 
     data = {"packages": packages_data}
@@ -76,6 +76,7 @@ def get_tidelift_data(packages):
     table = Table(show_header=True, header_style="bold magenta")
     table.add_column("#")
     table.add_column("Package Name")
+    table.add_column("Url")
     table.add_column("Estimated Money")
     table.add_column("Lifted")
 
@@ -92,9 +93,23 @@ def get_tidelift_data(packages):
     )  # sort lifted True first, then None, then False, then amount,  then by name
     for i, (name, lifted, estimated_money) in enumerate(package_data, start=1):
         if lifted:
-            table.add_row(str(i), name, "-- need login ––", f"[green]{lifted}[/green]")
+            table.add_row(
+                str(i),
+                name,
+                f"https://pypi.org/project/{name}",
+                "-- need login ––",
+                f"[green]{lifted}[/green]",
+            )
         else:
-            table.add_row(str(i), name, str(estimated_money), f"[red]{lifted}[/red]")
+            if only_liftable and estimated_money is None:
+                continue
+            table.add_row(
+                str(i),
+                name,
+                f"https://pypi.org/project/{name}",
+                str(estimated_money),
+                f"[red]{lifted}[/red]",
+            )
 
     print(table)
 
@@ -103,6 +118,7 @@ if __name__ == "__main__":
     # URL of the webpage
     args = sys.argv[1:]
     packages = []
+    only_liftable = False
     while args:
         if args[0] == "--org":
             url = f"https://pypi.org/org/{args[1]}/"
@@ -115,9 +131,12 @@ if __name__ == "__main__":
         elif args[0] == "--packages":
             packages += args[1:]
             args = []
+        elif args[0] == "--only-liftable":
+            only_liftable = True
+            args = args[1:]
         else:
             print(
                 "Invalid argument. Please use either --org ORG, --user USER or --packages PACKAGE1 PACKAGE2 ..."
             )
             exit(1)
-    get_tidelift_data(packages)
+    get_tidelift_data(packages, only_liftable=only_liftable)


### PR DESCRIPTION
This is a massive update to the tooling that try to find and map all of  github repo and corresponding pypi packages. 

This is to try to get a view of the scope of work jupyter is doing/have been done and control.

Imho this is some of the necessary steps for https://github.com/jupyter-governance/jupyter-foundation-governing-board/issues/1, as how can you decide where to allocate funds if you don't know where you can allocate them. 

output looks like this:

```
Found 107 packages in the pypi jupyter org
To add to PiPy org – they are listed on the config file, with a corresponding Pypi package, but the package is not part of Pypi org:
  https://pypi.org/project/chartpress maintained by
     pypi: `@yuvipanda` 
     pypi: `@jupyterhub-bot` 
     pypi: `@consideRatio` 
     pypi: `@willingc` 
     pypi: `@minrk` 
  https://pypi.org/project/nullauthenticator maintained by
     pypi: `@minrk` 
  https://pypi.org/project/jupyverse maintained by
     pypi: `@zsailer` 
     pypi: `@davidbrochart` 
  https://pypi.org/project/jupyterhub-nativeauthenticator maintained by

<snip 300 lines>

`@minrk` 28 packages (https://pypi.org/user/minrk/):
    https://pypi.org/project/binderhub
    https://pypi.org/project/chartpress
    https://pypi.org/project/docker-image-cleaner
    https://pypi.org/project/dockerspawner
    https://pypi.org/project/jupyter-repo2docker
    https://pypi.org/project/jupyter-rsession-proxy
    https://pypi.org/project/jupyter-server-proxy
    https://pypi.org/project/jupyterhub
    https://pypi.org/project/jupyterhub-carina
    https://pypi.org/project/jupyterhub-firstuseauthenticator
    https://pypi.org/project/jupyterhub-kubespawner/
    https://pypi.org/project/jupyterhub-ldapauthenticator
    https://pypi.org/project/jupyterhub-ltiauthenticator
    https://pypi.org/project/jupyterhub-nativeauthenticator
    https://pypi.org/project/jupyterhub-systemdspawner
    https://pypi.org/project/jupyterhub-tmpauthenticator
    https://pypi.org/project/jupyterhub-traefik-proxy
    https://pypi.org/project/jupyterlab_launcher
    https://pypi.org/project/nbgitpuller-downloader-dropbox
    https://pypi.org/project/nbgitpuller-downloader-generic-web
    https://pypi.org/project/nbgitpuller-downloader-googledrive
    https://pypi.org/project/nullauthenticator
    https://pypi.org/project/oauthenticator
    https://pypi.org/project/pickleshare
    https://pypi.org/project/pytest-jupyterhub
    https://pypi.org/project/qtconsole
    https://pypi.org/project/simpervisor
    https://pypi.org/project/sudospawner
`@consideRatio` 27 packages (https://pypi.org/user/consideRatio/):
    https://pypi.org/project/binderhub
    https://pypi.org/project/chartpress
    <snip 329 lines>

listing all org and repo under jupyter purview, and filtering one without mathching github repos.

check potentially matching Pypi names, all the following seem to correspond to an existing pypi package, if they indeed are part of Jupyter, you can copy past the lines as is in the config file. If not just append: `{org}/{repo}:`

jupyter/debugger                          :  https://pypi.org/project/debugger (archived) 
jupyter/experiments                       :  https://pypi.org/project/experiments (archived) 
jupyter/kernels                           :  https://pypi.org/project/kernels (archived) 
jupyter/markdown                          :  https://pypi.org/project/markdown  
jupyter/newsletter                        :  https://pypi.org/project/newsletter (archived) 
jupyter/practice                          :  https://pypi.org/project/practice  
jupyter/roadmap                           :  https://pypi.org/project/roadmap  
jupyter/schema                            :  https://pypi.org/project/schema  
jupyter/services                          :  https://pypi.org/project/services (archived) 
jupyter/showcase                          :  https://pypi.org/project/showcase (archived) 
jupyter/spreadsheet                       :  https://pypi.org/project/spreadsheet (archived) 
jupyter/telemetry                         :  https://pypi.org/project/telemetry  

jupyter-book/blog                         :  https://pypi.org/project/blog  
jupyter-book/meta                         :  https://pypi.org/project/meta  
jupyter-book/thebe                        :  https://pypi.org/project/thebe  



REDACTED private info

jupyter-standards/schemas                 :  https://pypi.org/project/schemas (archived) 


jupyter-xeus/xcanvas                      :  https://pypi.org/project/xcanvas  
jupyter-xeus/xena                         :  https://pypi.org/project/xena  


jupyterlab/benchmarks                     :  https://pypi.org/project/benchmarks  
REDACTED private info
jupyterlab/debugger                       :  https://pypi.org/project/debugger (archived) 
jupyterlab/pull-requests                  :  https://pypi.org/project/pull-requests  



repos with no Pypi package, either manually add `{org}/{repo}: {pypi_url}` or `{org}/{repo}: <blank>` to config file.

https://github.com/jupyter/atom-notebook  
https://github.com/jupyter/colaboratory (archived) 
https://github.com/jupyter/conf-event-log (archived) 
https://github.com/jupyter/cookiecutter-docker-stacks  
https://github.com/jupyter/dashboards_bundlers (archived) 
https://github.com/jupyter/dashboards_server (archived) 
https://github.com/jupyter/dashboards_setup (archived) 
<>snip 188 lines

```