### PR TITLE
Add precisions on disclosure timing to vulnerability handling guidelines

### DIFF
--- a/docs/vulnerability-handling.md
+++ b/docs/vulnerability-handling.md
@@ -17,11 +17,7 @@ This process applies to *all projects* governed by Jupyter, including JupyterLab
 
 ## Reporting Vulnerabilities
 
-If you believe you’ve found a security vulnerability in a Jupyter project, please report it to security@ipython.org. If you prefer 
-to encrypt your security reports, you can use [this PGP public key](https://jupyter.org/assets/ipython_security.asc). Project Jupyter 
-will respond within 3 days to all new reports.
-
-We are also testing GitHub Private vulnerability reporting, you can try to submit a security advisory on [jupyter/security using this link](https://github.com/jupyter/security/security/advisories/new).
+See https://jupyter.org/security.
 
 ## Coordinated Disclosures
 
@@ -69,13 +65,21 @@ The role responsible for each step is noted at the beginning.
     - **Developer**: Work on the [vulnerability fix PR](https://docs.github.com/en/code-security/repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability#creating-a-temporary-private-fork)
     - Once the fix is agreed upon, wait for the CVE number to be issued.
     - **Coordinator**: Notify the **Reporter** of the CVE number. Anyone may mention the CVE number publicly with the affected software name (without revealing version numbers).
-    - **Developer & Coordinator**: Decide on release and announcement dates and post them the draft advisory.  These are typically at least a week apart to allow administrators to deploy fixes.
-  - **Coordinator**: Post the release and announcement dates on the Jupyter Security [Mailing List]([security@ipython.org](mailto:security@ipython.org))
+    - **Developer & Coordinator**: Decide on release and announcement dates and post them the draft advisory. These are typically at least a week apart to allow administrators to deploy fixes.
+  - **Coordinator**: Post the release and announcement dates on the Jupyter Security [Mailing List]([security@jupyter.org](mailto:security@jupyter.org)). See [Disclosure timing](#disclosure-timing).
   - **Developer**: Merge the security fix PR
   - **Developer**: Make a release to PyPI and/or npm with standard changelog. The fixed CVEs should be mentioned. For example, see [Node.js](https://github.com/nodejs/node/blob/v24.14.1/doc/changelogs/CHANGELOG_V24.md#24.14.1)
   - **Coordinator**: Publish the security advisory on the announcement date.  GitHub will post the CVE to the MITRE database
 - **Coordinator**: Notify the **Reporter** of the releases
 - **Coordinator**: Close the issue in the tracking repository
+
+### Disclosure timing
+
+- **Default:** publish once internal packaging (PyPI/npm) is resolved.
+- **Severe vulnerabilities:** also wait until the patch is on [conda-forge](https://conda-forge.org/) and [docker-stacks](https://github.com/jupyter/docker-stacks).
+- **Most severe vulnerabilities:** also wait for relevant third-party channels (Anaconda, select Linux distros).
+
+If the coordinator wants to withhold some workarounds details (as these make discovering the attack steps easier), they should be free to do so but they should still publish the CVE and advisory with the severity classification and impacted versions range at a minimum. It should also include a note that the advisory will be updated with more details after a specific embargo time.
 
 ### Note to Developers
 


### PR DESCRIPTION
https://github.com/jupyter/security/issues/117#issuecomment-4243428873

Also update email and remove stale/duplicate vulnerability reporting guidelines